### PR TITLE
Add support for usage of percentages in `tabWidth`

### DIFF
--- a/de.manumaticx.pagingcontrol/controllers/tabs.js
+++ b/de.manumaticx.pagingcontrol/controllers/tabs.js
@@ -20,6 +20,14 @@ function init(args){
   _.defaults(opts, args);
 
   $.tabWidth = args.tabs.width || getTabWidth();
+  
+  if($.tabWidth.indexOf('%')) {
+    var newWidth = parseInt($.tabWidth.slice(0, $.tabWidth.indexOf('%')))/100;
+
+    OS_ANDROID && (newWidth /= Ti.Platform.displayCaps.logicalDensityFactor);
+
+    $.tabWidth = newWidth * Ti.Platform.displayCaps.platformWidth;
+  }
 
   $.tabs.applyProperties({
     left: 0,


### PR DESCRIPTION
I would like to use percentages for the Tabs width. I though it was possible, but got NaN errors, so added it to the widget.
